### PR TITLE
LinkDescriptorBuilder: changed the syntax for declaring collections

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractGenericOneMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractGenericOneMappableParameterMainStateImpl.java
@@ -1,19 +1,16 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.impl.main;
 
-import java.util.Collection;
-
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.bindgen.BindingRoot;
 import org.bindgen.binding.AbstractBinding;
 import org.javatuples.Unit;
-import org.springframework.core.convert.TypeDescriptor;
 
 import com.google.common.base.Predicate;
-import com.google.common.base.Supplier;
 
 import fr.openwide.core.wicket.more.condition.Condition;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.generic.IGenericOneMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.common.IOneChosenParameterState;
@@ -67,7 +64,7 @@ abstract class AbstractGenericOneMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<?> addedParameterType) {
 		super(previousState, addedParameterType);
 	}
 
@@ -82,25 +79,6 @@ abstract class AbstractGenericOneMappableParameterMainStateImpl
 	@Override
 	public IAddedParameterMappingState<TSelf> map(String parameterName) {
 		return pickLast().map(parameterName);
-	}
-
-	@Override
-	public <TElement> IAddedParameterMappingState<TSelf> mapCollection(
-			String parameterName, Class<TElement> elementType) {
-		return pickLast().mapCollection(parameterName, elementType);
-	}
-
-	@Override
-	public IAddedParameterMappingState<TSelf> mapCollection(
-			String parameterName, TypeDescriptor elementTypeDescriptor) {
-		return pickLast().mapCollection(parameterName, elementTypeDescriptor);
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Override
-	public <C extends Collection> IAddedParameterMappingState<TSelf> mapCollection(
-			String parameterName, TypeDescriptor elementTypeDescriptor, Supplier<C> emptyCollectionSupplier) {
-		return pickLast().mapCollection(parameterName, elementTypeDescriptor, emptyCollectionSupplier);
 	}
 
 	@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractMainStateImpl.java
@@ -24,12 +24,13 @@ import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilde
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderMapperLinkDescriptorFactory;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.AbstractCoreAddedParameterMapperStateImpl;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterMappingEntryBuilder;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.mapping.CollectionLinkParameterMappingEntry;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.mapping.SimpleLinkParameterMappingEntry;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.mapping.IAddedParameterMappingState;
-import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.CollectionLinkParameterMappingEntry;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.ILinkParameterMappingEntry;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.InjectOnlyLinkParameterMappingEntry;
-import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.SimpleLinkParameterMappingEntry;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.factory.ILinkParameterMappingEntryFactory;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.validator.ConditionLinkParameterValidator;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.validator.ILinkParameterValidator;
@@ -92,13 +93,14 @@ abstract class AbstractMainStateImpl
 	}
 
 	@Override
-	public <T> IAddedParameterMappingState<TSelf> map(String name, IModel<T> valueModel,
-			Class<T> valueType) {
+	public <T> IAddedParameterMappingState<TSelf> map(String name, IModel<T> valueModel, Class<T> valueType) {
 		Args.notNull(name, "name");
 		Args.notNull(valueModel, "valueModel");
 		Args.notNull(valueType, "valueType");
 	
-		return map(new SimpleLinkParameterMappingEntry<T>(name, valueModel, valueType));
+		return map(new SimpleLinkParameterMappingEntry<T>(
+				name, valueModel, LinkParameterTypeInformation.valueOf(valueType).getTypeDescriptorSupplier()
+		));
 	}
 	
 	@Override
@@ -114,9 +116,11 @@ abstract class AbstractMainStateImpl
 	public <RawC extends Collection, C extends RawC, T> IAddedParameterMappingState<TSelf>
 			mapCollection(String parameterName, IModel<C> valueModel, Class<RawC> rawCollectionType,
 					TypeDescriptor elementTypeDescriptor) {
-		return map(new CollectionLinkParameterMappingEntry<RawC, C>(
-				parameterName, valueModel, rawCollectionType, elementTypeDescriptor
-				));
+		return map(new CollectionLinkParameterMappingEntry<>(
+				parameterName, valueModel,
+				LinkParameterTypeInformation.collection(rawCollectionType, elementTypeDescriptor)
+						.getTypeDescriptorSupplier()
+		));
 	}
 	
 	@Override
@@ -124,9 +128,12 @@ abstract class AbstractMainStateImpl
 	public <RawC extends Collection, C extends RawC, T> IAddedParameterMappingState<TSelf>
 			mapCollection(String parameterName, IModel<C> valueModel, Class<RawC> rawCollectionType,
 					TypeDescriptor elementTypeDescriptor, Supplier<C> emptyCollectionSupplier) {
-		return map(new CollectionLinkParameterMappingEntry<RawC, C>(
-				parameterName, valueModel, rawCollectionType, elementTypeDescriptor, emptyCollectionSupplier
-				));
+		return map(new CollectionLinkParameterMappingEntry<>(
+				parameterName, valueModel,
+				LinkParameterTypeInformation.collection(rawCollectionType, elementTypeDescriptor)
+						.getTypeDescriptorSupplier(),
+				emptyCollectionSupplier
+		));
 	}
 	
 	protected final <TTuple extends Tuple> IAddedParameterMappingState<TSelf>

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractOneOrMoreMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/AbstractOneOrMoreMappableParameterMainStateImpl.java
@@ -7,6 +7,7 @@ import org.apache.wicket.util.lang.Args;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.AbstractChosenParameterStateImpl;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.mapping.IAddedParameterMappingState;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.factory.ILinkParameterMappingEntryFactory;
@@ -28,8 +29,8 @@ abstract class AbstractOneOrMoreMappableParameterMainStateImpl
 						TLateTargetDefinitionResourceLinkDescriptor,
 						TLateTargetDefinitionImageResourceLinkDescriptor
 						> {
-	
-	protected final List<Class<?>> dynamicParameterTypes;
+
+	protected final List<LinkParameterTypeInformation<?>> dynamicParameterTypes;
 	
 	public AbstractOneOrMoreMappableParameterMainStateImpl(
 			NoMappableParameterMainStateImpl<
@@ -38,9 +39,9 @@ abstract class AbstractOneOrMoreMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<?> addedParameterType) {
 		super(previousState);
-		this.dynamicParameterTypes = ImmutableList.<Class<?>>of(addedParameterType);
+		this.dynamicParameterTypes = ImmutableList.<LinkParameterTypeInformation<?>>of(addedParameterType);
 	}
 	
 	public AbstractOneOrMoreMappableParameterMainStateImpl(
@@ -51,9 +52,9 @@ abstract class AbstractOneOrMoreMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType, int expectedNumberOfParameters) {
+			LinkParameterTypeInformation<?> addedParameterType, int expectedNumberOfParameters) {
 		super(previousState);
-		this.dynamicParameterTypes = ImmutableList.<Class<?>>builder()
+		this.dynamicParameterTypes = ImmutableList.<LinkParameterTypeInformation<?>>builder()
 				.addAll(previousState.dynamicParameterTypes).add(addedParameterType).build();
 		Args.withinRange(
 				expectedNumberOfParameters, expectedNumberOfParameters,
@@ -66,7 +67,7 @@ abstract class AbstractOneOrMoreMappableParameterMainStateImpl
 			extends AbstractChosenParameterStateImpl<TSelfChosen, TSelf> {
 		
 		@Override
-		protected Class<?> getParameterType(int index) {
+		protected LinkParameterTypeInformation<?> getParameterTypeInformation(int index) {
 			return dynamicParameterTypes.get(index);
 		}
 		

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/FourMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/FourMappableParameterMainStateImpl.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.BuilderTargetFactories;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderLinkDescriptorFactory;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.mapper.CoreFourParameterLinkDescriptorMapperImpl;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IFourMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.IFourMappableParameterFourChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.IFourMappableParameterOneChosenParameterState;
@@ -62,7 +63,7 @@ final class FourMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<TParam4> addedParameterType) {
 		super(previousState, addedParameterType, 4);
 	}
 

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/NoMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/NoMappableParameterMainStateImpl.java
@@ -1,15 +1,20 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.impl.main;
 
+import java.util.Collection;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.javatuples.Tuple;
+import org.springframework.core.convert.TypeDescriptor;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.BuilderTargetFactories;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderLinkDescriptorFactory;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.INoMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IOneMappableParameterMainState;
 import fr.openwide.core.wicket.more.markup.html.factory.ModelFactories;
@@ -60,8 +65,50 @@ public final class NoMappableParameterMainStateImpl
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam1> clazz) {
-		return new OneMappableParameterMainStateImpl<>(this, clazz);
+			> model(Class<TParam1> clazz) {
+		return new OneMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.valueOf(clazz)
+		);
+	}
+	
+	@Override
+	public <TParam1 extends Collection<TElement>, TElement> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, Class<TElement> elementType) {
+		return new OneMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementType)
+		);
+	}
+	
+	@Override
+	public <TParam1 extends Collection<?>> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, TypeDescriptor elementTypeDescriptor) {
+		return new OneMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor)
+		);
+	}
+	
+	@Override
+	public <TParam1 extends Collection<?>> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam1> emptyCollectionSupplier) {
+		return new OneMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor, emptyCollectionSupplier)
+		);
 	}
 	
 	private <TTarget, TLinkDescriptor> TLinkDescriptor createLinkDescriptor(

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/OneMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/OneMappableParameterMainStateImpl.java
@@ -1,5 +1,6 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.impl.main;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.wicket.Page;
@@ -7,13 +8,17 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.javatuples.Tuple;
+import org.springframework.core.convert.TypeDescriptor;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.BuilderTargetFactories;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderLinkDescriptorFactory;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.mapper.CoreOneParameterLinkDescriptorMapperImpl;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IOneMappableParameterMainState;
+import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.ITwoMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.IOneMappableParameterOneChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.mapper.IOneParameterLinkDescriptorMapper;
 import fr.openwide.core.wicket.more.markup.html.factory.IDetachableFactory;
@@ -78,7 +83,7 @@ final class OneMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<TParam1> addedParameterType) {
 		super(previousState, addedParameterType);
 	}
 
@@ -89,8 +94,50 @@ final class OneMappableParameterMainStateImpl
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam2> clazz) {
-		return new TwoMappableParameterMainStateImpl<>(this, clazz);
+			> model(Class<TParam2> clazz) {
+		return new TwoMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.valueOf(clazz)
+		);
+	}
+
+	@Override
+	public <TParam2 extends Collection<TElement>, TElement> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, Class<TElement> elementType) {
+		return new TwoMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementType)
+		);
+	}
+	
+	@Override
+	public <TParam2 extends Collection<?>> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, TypeDescriptor elementTypeDescriptor) {
+		return new TwoMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor)
+		);
+	}
+	
+	@Override
+	public <TParam2 extends Collection<?>> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam2> emptyCollectionSupplier) {
+		return new TwoMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor, emptyCollectionSupplier)
+		);
 	}
 	
 	private <TTarget, TLinkDescriptor> IOneParameterLinkDescriptorMapper<TLinkDescriptor, TParam1>

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/ThreeMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/ThreeMappableParameterMainStateImpl.java
@@ -1,5 +1,6 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.impl.main;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.wicket.Page;
@@ -7,12 +8,16 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.javatuples.Tuple;
+import org.springframework.core.convert.TypeDescriptor;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.BuilderTargetFactories;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderLinkDescriptorFactory;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.mapper.CoreThreeParameterLinkDescriptorMapperImpl;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
+import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IFourMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IThreeMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.IThreeMappableParameterOneChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.IThreeMappableParameterThreeChosenParameterState;
@@ -61,7 +66,7 @@ final class ThreeMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<TParam3> addedParameterType) {
 		super(previousState, addedParameterType, 3);
 	}
 	
@@ -72,10 +77,52 @@ final class ThreeMappableParameterMainStateImpl
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam4> clazz) {
-		return new FourMappableParameterMainStateImpl<>(this, clazz);
+			> model(Class<TParam4> clazz) {
+		return new FourMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.valueOf(clazz)
+		);
 	}
 
+	@Override
+	public <TParam4 extends Collection<TElement>, TElement> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, Class<TElement> elementType) {
+		return new FourMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementType)
+		);
+	}
+	
+	@Override
+	public <TParam4 extends Collection<?>> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, TypeDescriptor elementTypeDescriptor) {
+		return new FourMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor)
+		);
+	}
+	
+	@Override
+	public <TParam4 extends Collection<?>> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam4> emptyCollectionSupplier) {
+		return new FourMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor, emptyCollectionSupplier)
+		);
+	}
+	
 	private <TTarget, TLinkDescriptor> IThreeParameterLinkDescriptorMapper<TLinkDescriptor, TParam1, TParam2, TParam3>
 			createMapper(IBuilderLinkDescriptorFactory<TTarget, TLinkDescriptor> linkDescriptorFactory,
 					IDetachableFactory<? extends Tuple, ? extends IModel<? extends TTarget>> pageClassFactory,

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/TwoMappableParameterMainStateImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/main/TwoMappableParameterMainStateImpl.java
@@ -1,5 +1,6 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.impl.main;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.wicket.Page;
@@ -7,12 +8,16 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.javatuples.Tuple;
+import org.springframework.core.convert.TypeDescriptor;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.BuilderTargetFactories;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.factory.IBuilderLinkDescriptorFactory;
 import fr.openwide.core.wicket.more.link.descriptor.builder.impl.mapper.CoreTwoParameterLinkDescriptorMapperImpl;
+import fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.LinkParameterTypeInformation;
+import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.IThreeMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.ITwoMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.ITwoMappableParameterOneChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.ITwoMappableParameterTwoChosenParameterState;
@@ -60,7 +65,7 @@ final class TwoMappableParameterMainStateImpl
 					TLateTargetDefinitionResourceLinkDescriptor,
 					TLateTargetDefinitionImageResourceLinkDescriptor
 					> previousState,
-			Class<?> addedParameterType) {
+			LinkParameterTypeInformation<TParam2> addedParameterType) {
 		super(previousState, addedParameterType, 2);
 	}
 	
@@ -71,8 +76,50 @@ final class TwoMappableParameterMainStateImpl
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam3> clazz) {
-		return new ThreeMappableParameterMainStateImpl<>(this, clazz);
+			> model(Class<TParam3> clazz) {
+		return new ThreeMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.valueOf(clazz)
+		);
+	}
+	
+	@Override
+	public <TParam3 extends Collection<TElement>, TElement> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, Class<TElement> elementType) {
+		return new ThreeMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementType)
+		);
+	}
+	
+	@Override
+	public <TParam3 extends Collection<?>> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, TypeDescriptor elementTypeDescriptor) {
+		return new ThreeMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor)
+		);
+	}
+	
+	@Override
+	public <TParam3 extends Collection<?>> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam3> emptyCollectionSupplier) {
+		return new ThreeMappableParameterMainStateImpl<>(
+				this, LinkParameterTypeInformation.collection(clazz, elementTypeDescriptor, emptyCollectionSupplier)
+		);
 	}
 
 	private <TTarget, TLinkDescriptor> ITwoParameterLinkDescriptorMapper<TLinkDescriptor, TParam1, TParam2>

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/parameter/LinkParameterTypeInformation.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/parameter/LinkParameterTypeInformation.java
@@ -1,0 +1,94 @@
+package fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter;
+
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
+import fr.openwide.core.commons.util.functional.SerializableSupplier;
+
+public class LinkParameterTypeInformation<T> {
+	
+	/**
+	 * We must wrap the typedescriptor in a supplier, since it is not serializable, and clients are serializable (so
+	 * they cannot hold references to non-serializable objects).
+	 */
+	private final Supplier<? extends TypeDescriptor> typeDescriptorSupplier;
+	
+	private final Supplier<? extends T> emptyValueSupplier;
+	
+	public static <T> LinkParameterTypeInformation<T> valueOf(final Class<T> clazz) {
+		return new LinkParameterTypeInformation<T>(
+				new SerializableSupplier<TypeDescriptor>() {
+					private static final long serialVersionUID = 1L;
+					@Override
+					public TypeDescriptor get() {
+						return TypeDescriptor.valueOf(clazz);
+					}
+				},
+				null
+		);
+	}
+	
+	public static <T extends Collection<TElement>, TElement> LinkParameterTypeInformation<T> collection(
+			final Class<? super T> clazz, final Class<TElement> elementType) {
+		return new LinkParameterTypeInformation<T>(
+				new SerializableSupplier<TypeDescriptor>() {
+					private static final long serialVersionUID = 1L;
+					@Override
+					public TypeDescriptor get() {
+						return TypeDescriptor.collection(clazz, TypeDescriptor.valueOf(elementType));
+					}
+				},
+				null
+		);
+	}
+	
+	public static <T extends Collection<?>> LinkParameterTypeInformation<T> collection(
+			final Class<? super T> clazz, final TypeDescriptor elementType) {
+		return new LinkParameterTypeInformation<T>(
+				new SerializableSupplier<TypeDescriptor>() {
+					private static final long serialVersionUID = 1L;
+					@Override
+					public TypeDescriptor get() {
+						return TypeDescriptor.collection(clazz, elementType);
+					}
+				},
+				null
+		);
+	}
+	
+	public static <T extends Collection<?>> LinkParameterTypeInformation<T> collection(
+			final Class<? super T> clazz, final TypeDescriptor elementType, Supplier<? extends T> emptyValueSupplier) {
+		return new LinkParameterTypeInformation<T>(
+				new SerializableSupplier<TypeDescriptor>() {
+					private static final long serialVersionUID = 1L;
+					@Override
+					public TypeDescriptor get() {
+						return TypeDescriptor.collection(clazz, elementType);
+					}
+				},
+				emptyValueSupplier
+		);
+	}
+
+	private LinkParameterTypeInformation(Supplier<? extends TypeDescriptor> typeDescriptorSupplier,
+			Supplier<? extends T> emptyValueSupplier) {
+		super();
+		this.typeDescriptorSupplier = typeDescriptorSupplier;
+		this.emptyValueSupplier = emptyValueSupplier;
+	}
+
+	public Supplier<? extends TypeDescriptor> getTypeDescriptorSupplier() {
+		return typeDescriptorSupplier;
+	}
+
+	@Nullable
+	public Supplier<? extends T> getEmptyValueSupplier() {
+		return emptyValueSupplier;
+	}
+	
+}

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/parameter/mapping/SimpleLinkParameterMappingEntry.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/impl/parameter/mapping/SimpleLinkParameterMappingEntry.java
@@ -1,15 +1,19 @@
-package fr.openwide.core.wicket.more.link.descriptor.parameter.mapping;
+package fr.openwide.core.wicket.more.link.descriptor.builder.impl.parameter.mapping;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.lang.Args;
 import org.javatuples.Unit;
+import org.springframework.core.convert.TypeDescriptor;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import fr.openwide.core.wicket.more.link.descriptor.parameter.extractor.LinkParameterExtractionException;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.injector.LinkParameterInjectionException;
+import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.AbstractLinkParameterMappingEntry;
+import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.ILinkParameterMappingEntry;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.factory.AbstractLinkParameterMappingEntryFactory;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.mapping.factory.ILinkParameterMappingEntryFactory;
 import fr.openwide.core.wicket.more.link.descriptor.parameter.validator.ILinkParameterValidator;
@@ -20,27 +24,31 @@ public class SimpleLinkParameterMappingEntry<T> extends AbstractLinkParameterMap
 	
 	private static final long serialVersionUID = -8490340879965229874L;
 	
-	public static <T> ILinkParameterMappingEntryFactory<Unit<IModel<T>>> factory(final String parameterName, final Class<T> valueType) {
+	public static <T> ILinkParameterMappingEntryFactory<Unit<IModel<T>>> factory(final String parameterName,
+			final Supplier<? extends TypeDescriptor> typeDescriptorSupplier) {
 		Args.notNull(parameterName, "parameterName");
-		Args.notNull(valueType, "valueType");
+		Args.notNull(typeDescriptorSupplier, "typeDescriptorSupplier");
 		
 		return new AbstractLinkParameterMappingEntryFactory<Unit<IModel<T>>>() {
 			private static final long serialVersionUID = 1L;
 			@Override
 			public ILinkParameterMappingEntry create(Unit<IModel<T>> parameters) {
-				return new SimpleLinkParameterMappingEntry<T>(parameterName, parameters.getValue0(), valueType);
+				return new SimpleLinkParameterMappingEntry<T>(
+						parameterName, parameters.getValue0(), typeDescriptorSupplier
+				);
 			}
 		};
 	}
 	
 	protected final String parameterName;
 	protected final IModel<T> mappedModel;
-	protected final Class<T> mappedType;
+	protected final Supplier<? extends TypeDescriptor> typeDescriptorSupplier;
 	
-	public SimpleLinkParameterMappingEntry(String parameterName, IModel<T> mappedModel, Class<T> mappedType) {
+	public SimpleLinkParameterMappingEntry(String parameterName, IModel<T> mappedModel,
+			Supplier<? extends TypeDescriptor> typeDescriptorSupplier) {
 		this.parameterName = parameterName;
 		this.mappedModel = mappedModel;
-		this.mappedType = mappedType;
+		this.typeDescriptorSupplier = typeDescriptorSupplier;
 	}
 	
 	@Override
@@ -49,14 +57,18 @@ public class SimpleLinkParameterMappingEntry<T> extends AbstractLinkParameterMap
 	}
 	
 	@Override
+	@SuppressWarnings("unchecked")
 	public void extract(PageParameters sourceParameters, ILinkParameterConversionService conversionService) throws LinkParameterExtractionException {
-		mappedModel.setObject(extract(sourceParameters, conversionService, parameterName, mappedType));
+		TypeDescriptor mappedType = typeDescriptorSupplier.get();
+		mappedModel.setObject((T) mappedType.getType().cast(
+				extract(sourceParameters, conversionService, parameterName, mappedType)
+		));
 	}
 	
 	@Override
 	public ILinkParameterMappingEntry wrap(Component component) {
 		IModel<T> wrappedModel = wrap(mappedModel, component);
-		return new SimpleLinkParameterMappingEntry<T>(parameterName, wrappedModel, mappedType);
+		return new SimpleLinkParameterMappingEntry<T>(parameterName, wrappedModel, typeDescriptorSupplier);
 	}
 	
 	@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/INoMappableParameterMainState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/INoMappableParameterMainState.java
@@ -1,5 +1,11 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.state.main;
 
+import java.util.Collection;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMappableParameterDeclarationState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.terminal.IBackwardCompatibleTerminalState;
@@ -49,6 +55,34 @@ public interface INoMappableParameterMainState
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam1> clazz);
+			> model(Class<TParam1> clazz);
+	
+	@Override
+	<TParam1 extends Collection<TElement>, TElement> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, Class<TElement> elementType);
+	
+	@Override
+	<TParam1 extends Collection<?>> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, TypeDescriptor elementTypeDescriptor);
+	
+	@Override
+	<TParam1 extends Collection<?>> IOneMappableParameterMainState<
+			TParam1,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam1> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam1> emptyCollectionSupplier);
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/IOneMappableParameterMainState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/IOneMappableParameterMainState.java
@@ -1,8 +1,15 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.state.main;
 
+import java.util.Collection;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMappableParameterDeclarationState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.generic.IGenericOneMappableParameterMainState;
+import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.common.IChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.common.IOneChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.terminal.IBackwardCompatibleTerminalState;
 import fr.openwide.core.wicket.more.link.descriptor.mapper.IOneParameterLinkDescriptorMapper;
@@ -66,6 +73,34 @@ public interface IOneMappableParameterMainState
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam2> clazz);
+			> model(Class<TParam2> clazz);
+	
+	@Override
+	<TParam2 extends Collection<TElement>, TElement> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, Class<TElement> elementType);
+	
+	@Override
+	<TParam2 extends Collection<?>> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, TypeDescriptor elementTypeDescriptor);
+	
+	@Override
+	<TParam2 extends Collection<?>> ITwoMappableParameterMainState<
+			TParam1, TParam2,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam2> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam2> emptyCollectionSupplier);
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/IThreeMappableParameterMainState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/IThreeMappableParameterMainState.java
@@ -1,5 +1,11 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.state.main;
 
+import java.util.Collection;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMappableParameterDeclarationState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.generic.IGenericThreeMappableParameterMainState;
@@ -67,6 +73,34 @@ public interface IThreeMappableParameterMainState
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam4> clazz);
+			> model(Class<TParam4> clazz);
+	
+	@Override
+	<TParam4 extends Collection<TElement>, TElement> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, Class<TElement> elementType);
+	
+	@Override
+	<TParam4 extends Collection<?>> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, TypeDescriptor elementTypeDescriptor);
+	
+	@Override
+	<TParam4 extends Collection<?>> IFourMappableParameterMainState<
+			TParam1, TParam2, TParam3, TParam4,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam4> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam4> emptyCollectionSupplier);
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/ITwoMappableParameterMainState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/ITwoMappableParameterMainState.java
@@ -1,5 +1,11 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.state.main;
 
+import java.util.Collection;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common.IMappableParameterDeclarationState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.generic.IGenericTwoMappableParameterMainState;
@@ -67,6 +73,34 @@ public interface ITwoMappableParameterMainState
 			TLateTargetDefinitionPageLinkDescriptor,
 			TLateTargetDefinitionResourceLinkDescriptor,
 			TLateTargetDefinitionImageResourceLinkDescriptor
-			> model(Class<? super TParam3> clazz);
+			> model(Class<TParam3> clazz);
+	
+	@Override
+	<TParam3 extends Collection<TElement>, TElement> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, Class<TElement> elementType);
+	
+	@Override
+	<TParam3 extends Collection<?>> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, TypeDescriptor elementTypeDescriptor);
+	
+	@Override
+	<TParam3 extends Collection<?>> IThreeMappableParameterMainState<
+			TParam1, TParam2, TParam3,
+			TEarlyTargetDefinitionLinkDescriptor,
+			TLateTargetDefinitionPageLinkDescriptor,
+			TLateTargetDefinitionResourceLinkDescriptor,
+			TLateTargetDefinitionImageResourceLinkDescriptor
+			> model(Class<? super TParam3> clazz, TypeDescriptor elementTypeDescriptor,
+						Supplier<? extends TParam3> emptyCollectionSupplier);
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/common/IMappableParameterDeclarationState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/main/common/IMappableParameterDeclarationState.java
@@ -1,5 +1,12 @@
 package fr.openwide.core.wicket.more.link.descriptor.builder.state.main.common;
 
+import java.util.Collection;
+import java.util.TreeSet;
+
+import org.springframework.core.convert.TypeDescriptor;
+
+import com.google.common.base.Supplier;
+
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.main.INoMappableParameterMainState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.common.IChosenParameterState;
 import fr.openwide.core.wicket.more.link.descriptor.builder.state.parameter.chosen.common.IOneChosenParameterState;
@@ -20,6 +27,43 @@ public interface IMappableParameterDeclarationState {
 	 * @return A builder state that allows for referencing the newly-added parameter. The exact type of this state is
 	 * defined in extending interfaces such as {@link INoMappableParameterMainState}.
 	 */
-	<TParam> IMainState<?> model(Class<? super TParam> clazz);
+	<TParam> IMainState<?> model(Class<TParam> clazz);
+	
+	/**
+	 * {@link #model(Class) Declare a mappable parameter of Collection type}.
+	 * <p>This method should be used when the model is expected to contain an {@link Collection},
+	 * since it enables implementors to convert the collection's elements as well as the collection itself.
+	 * @param clazz The type of the parameter on the Java side, i.e. the type of objects that will be contained in models
+	 * passed to the {@link IOneParameterLinkDescriptorMapper#map(org.apache.wicket.model.IModel) link descriptor mapper}.
+	 * @param elementType The expected type of elements stored in the parameter.
+	 * @return A builder state that allows for referencing the newly-added parameter. The exact type of this state is
+	 * defined in extending interfaces such as {@link INoMappableParameterMainState}.
+	 * @see #model(Class)
+	 */
+	<TParam extends Collection<TElement>, TElement> IMainState<?> model(Class<? super TParam> clazz,
+			Class<TElement> elementType);
+	
+	/**
+	 * {@link #model(Class) Declare a mappable parameter of Collection type}.
+	 * <p>This method should be used when the model is expected to contain an {@link Collection},
+	 * since it enables implementors to convert the collection's elements as well as the collection itself.
+	 * @param clazz The type of the parameter on the Java side, i.e. the type of objects that will be contained in models
+	 * passed to the {@link IOneParameterLinkDescriptorMapper#map(org.apache.wicket.model.IModel) link descriptor mapper}.
+	 * @param elementTypeDescriptor The expected type of elements stored in the parameter.
+	 * @return A builder state that allows for referencing the newly-added parameter. The exact type of this state is
+	 * defined in extending interfaces such as {@link INoMappableParameterMainState}.
+	 * @see #model(Class)
+	 */
+	<TParam extends Collection<?>> IMainState<?> model(Class<? super TParam> clazz,
+			TypeDescriptor elementTypeDescriptor);
+
+	/**
+	 * Similar to {@link #model(Class, TypeDescriptor)}, but additionally allows to define the
+	 * exact collection implementation to use (for instance a {@link TreeSet} even if the raw type is simply
+	 * {@link Collection}).
+	 * @see #model(Class, TypeDescriptor)
+	 */
+	<TParam extends Collection<?>> IMainState<?> model(Class<? super TParam> clazz,
+			TypeDescriptor elementTypeDescriptor, Supplier<? extends TParam> emptyCollectionSupplier);
 	
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/parameter/chosen/common/IOneChosenParameterState.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/link/descriptor/builder/state/parameter/chosen/common/IOneChosenParameterState.java
@@ -56,37 +56,6 @@ public interface IOneChosenParameterState
 	IAddedParameterMappingState<TInitialState> map(String parameterName);
 
 	/**
-	 * Map the HTTP query parameter with the given name to the currently selected model.
-	 * <p>This method should be used when the model is expected to contain a collection, since it enables implementors
-	 * to convert collection elements as well as the collection itself.
-	 * @param parameterName The HTTP query parameter name.
-	 * @param elementType The expected type of elements stored in the collection (for use during conversion).
-	 * @see #map(String, IModel, Class)
-	 */
-	<TElement> IAddedParameterMappingState<TInitialState> mapCollection(
-			String parameterName, Class<TElement> elementType);
-
-	/**
-	 * Map the HTTP query parameter with the given name to the currently selected model.
-	 * <p>This method should be used when the model is expected to contain a <strong>collection of collections</strong>,
-	 * since it enables implementors to convert collection elements as well as the collection itself.
-	 * @param parameterName The HTTP query parameter name.
-	 * @param elementType The expected type of elements stored in the collection (for use during conversion).
-	 * @see #map(String, IModel, Class)
-	 */
-	IAddedParameterMappingState<TInitialState> mapCollection(
-			String parameterName, TypeDescriptor elementTypeDescriptor);
-
-	/**
-	 * Similar to {@link #mapCollection(String, TypeDescriptor)}, but additionally allows to define the
-	 * exact collection implementation to use (for instance a {@link TreeSet} even if the raw type is simply
-	 * {@link Collection}).
-	 */
-	@SuppressWarnings("rawtypes")
-	<C extends Collection> IAddedParameterMappingState<TInitialState> mapCollection(
-			String parameterName, TypeDescriptor elementTypeDescriptor, Supplier<C> emptyCollectionSupplier);
-
-	/**
 	 * Map HTTP query parameter with the given name to the currently selected model, making sure that:
 	 * <ul>
 	 * <li>when {@link ILinkParametersExtractor extracting parameters} from a HTTP query, the parameter


### PR DESCRIPTION
Basically, what we previously wrote this way:

```
                        LinkDescriptorBuilder.start()
                        .<List<Long>>model(List.class)
                        .mapCollection(CommonParameters.ID, Long.class).optional()
                        .page(MyPage.class)
```

will now have to be written this way:

```
                        LinkDescriptorBuilder.start()
                        .<List<Long>, Long>model(List.class, Long.class)
                        .map(CommonParameters.ID).optional()
                        .page(MyPage.class)
```

I think it makes more sense, and the mapping is more consistent with non-collection types.
Plus, this feature is rarely used, so the API break is no big deal.
