### PR TITLE
Introduced IReference et al.

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/EntityDaoImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/EntityDaoImpl.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Lists;
 
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.business.generic.model.GenericEntityCollectionReference;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 
 @Repository("entityDao")
 public class EntityDaoImpl implements IEntityDao {
@@ -35,8 +35,8 @@ public class EntityDaoImpl implements IEntityDao {
 	}
 	
 	@Override
-	public <E extends GenericEntity<?, ?>> E getEntity(GenericEntityReference<?, E> reference) {
-		return entityManager.find(reference.getType(), reference.getId());
+	public <E extends GenericEntity<?, ?>> E getEntity(IReference<E> reference) {
+		return reference == null ? null : entityManager.find(reference.getType(), reference.getId());
 	}
 	
 	@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/GenericEntityDaoImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/GenericEntityDaoImpl.java
@@ -27,7 +27,7 @@ import javax.persistence.metamodel.SingularAttribute;
 import com.querydsl.core.types.dsl.PathBuilder;
 
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 import fr.openwide.core.jpa.business.generic.util.GenericEntityUtils;
 
 /**
@@ -83,8 +83,9 @@ public abstract class GenericEntityDaoImpl<K extends Serializable & Comparable<K
 	}
 	
 	@Override
-	public <T extends E> T getById(GenericEntityReference<K, T> reference) {
-		return getById(reference.getType(), reference.getId());
+	@SuppressWarnings("unchecked")
+	public <T extends E> T getById(IReference<T> reference) {
+		return reference == null ? null : getById(reference.getType(), (K) reference.getId());
 	}
 	
 	@Override

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/IEntityDao.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/IEntityDao.java
@@ -6,13 +6,13 @@ import java.util.List;
 
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.business.generic.model.GenericEntityCollectionReference;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 
 public interface IEntityDao {
 	
 	<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> E getEntity(Class<E> clazz, K id);
 	
-	<E extends GenericEntity<?, ?>> E getEntity(GenericEntityReference<?, E> reference);
+	<E extends GenericEntity<?, ?>> E getEntity(IReference<E> reference);
 
 	<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> List<E> listEntity(Class<E> clazz, Collection<K> ids);
 	

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/IGenericEntityDao.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/dao/IGenericEntityDao.java
@@ -33,7 +33,7 @@ import javax.persistence.criteria.Order;
 import javax.persistence.metamodel.SingularAttribute;
 
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 
 /**
  * <p>DAO racine pour la gestion des entités.</p>
@@ -78,7 +78,7 @@ public interface IGenericEntityDao<K extends Serializable & Comparable<K>, E ext
 	 * @param reference
 	 * @return entité
 	 */
-	<T extends E> T getById(GenericEntityReference<K, T> reference);
+	<T extends E> T getById(IReference<T> reference);
 	
 	/**
 	 * Retourne une entité à partir de son id naturelle (si elle a été déclarée avec @NaturalId)

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/GenericEntity.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/GenericEntity.java
@@ -49,7 +49,7 @@ import fr.openwide.core.commons.util.ordering.SerializableCollator;
  */
 @MappedSuperclass
 public abstract class GenericEntity<K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>>
-		implements Serializable, Comparable<E>, IGenericEntityBindingInterface {
+		implements Serializable, Comparable<E>, IReferenceable<E>, IGenericEntityBindingInterface {
 
 	private static final long serialVersionUID = -3988499137919577054L;
 	
@@ -69,6 +69,13 @@ public abstract class GenericEntity<K extends Comparable<K> & Serializable, E ex
 		DEFAULT_STRING_COLLATOR = collator.nullsLast();
 	}
 	
+	@Override
+	@Transient
+	@SuppressWarnings("unchecked")
+	public GenericEntityReference<K, E> asReference() {
+		return GenericEntityReference.of((E)this);
+	}
+
 	/**
 	 * Retourne la valeur de l'identifiant unique.
 	 * 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/GenericEntityReference.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/GenericEntityReference.java
@@ -8,6 +8,7 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.Transient;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -25,7 +26,7 @@ import fr.openwide.core.jpa.search.util.HibernateSearchAnalyzer;
 @MappedSuperclass
 @Access(AccessType.FIELD)
 public class GenericEntityReference<K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>>
-		implements Serializable {
+		implements IReference<E>, Serializable {
 	
 	private static final long serialVersionUID = 1357434247523209721L;
 	
@@ -39,7 +40,8 @@ public class GenericEntityReference<K extends Comparable<K> & Serializable, E ex
 	@Field(analyzer = @Analyzer(definition = HibernateSearchAnalyzer.KEYWORD))
 	private /* final */ K id;
 
-	public static <K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>> GenericEntityReference<K, E> of(E entity) {
+	public static <K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>>
+			GenericEntityReference<K, E> of(E entity) {
 		return entity == null || entity.isNew() ? null : new GenericEntityReference<K, E>(entity);
 	}
 
@@ -48,8 +50,8 @@ public class GenericEntityReference<K extends Comparable<K> & Serializable, E ex
 		return entity == null || entity.isNew() ? null : (GenericEntityReference<?, E>) new GenericEntityReference(entity);
 	}
 
-	public static <K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>> GenericEntityReference<K, E> of(
-			Class<? extends E> entityClass, K entityId) {
+	public static <K extends Comparable<K> & Serializable, E extends GenericEntity<K, ?>> GenericEntityReference<K, E>
+			of(Class<? extends E> entityClass, K entityId) {
 		return new GenericEntityReference<K, E>(entityClass, entityId);
 	}
 	
@@ -71,10 +73,12 @@ public class GenericEntityReference<K extends Comparable<K> & Serializable, E ex
 		this.id = entityId;
 	}
 
+	@Override
 	public Class<? extends E> getType() {
 		return type;
 	}
 
+	@Override
 	public K getId() {
 		return id;
 	}
@@ -140,6 +144,18 @@ public class GenericEntityReference<K extends Comparable<K> & Serializable, E ex
 				.append("class", getType())
 				.append("id", getId())
 				.build();
+	}
+	
+	@Override
+	@Transient
+	public GenericEntityReference<K, E> asReference() {
+		return this;
+	}
+	
+	@Override
+	@Transient
+	public boolean matches(E referenceable) {
+		return referenceable != null && equals(referenceable.asReference());
 	}
 
 }

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/IReference.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/IReference.java
@@ -1,0 +1,18 @@
+package fr.openwide.core.jpa.business.generic.model;
+
+import java.io.Serializable;
+
+/**
+ * A serializable reference to a {@link IReferenceable} (generally an entity).
+ */
+public interface IReference<E> extends IReferenceable<E>, Serializable {
+	
+	/**
+	 * The type that is referenced.
+	 * <p>IDs are supposed to be unique among all instances of a given type.
+	 */
+	Class<? extends E> getType();
+	
+	boolean matches(E referenceable);
+	
+}

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/IReferenceable.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/IReferenceable.java
@@ -1,0 +1,14 @@
+package fr.openwide.core.jpa.business.generic.model;
+
+
+/**
+ * An object that can provide a {@link IReference} that will refer to the same object as itself.
+ * <p>This interface is implemented by both {@link GenericEntity} and {@link GenericEntityReference}, 
+ */
+public interface IReferenceable<E> {
+	
+	Object getId();
+
+	IReference<E> asReference();
+
+}

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/migration/MigratedFromOldApplicationGenericEntity.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/model/migration/MigratedFromOldApplicationGenericEntity.java
@@ -17,7 +17,7 @@ import fr.openwide.core.jpa.business.generic.model.GenericEntity;
  * @see MigratedFromOldApplicationSequenceGenerator
  */
 @MappedSuperclass
-public abstract class MigratedFromOldApplicationGenericEntity<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>>
+public abstract class MigratedFromOldApplicationGenericEntity<K extends Serializable & Comparable<K>, E extends GenericEntity<K, E>>
 		extends GenericEntity<K, E> implements IMigratedFromOldApplicationEntity<K> {
 
 	private static final long serialVersionUID = 2034570162020079499L;

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/EntityServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/EntityServiceImpl.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Service;
 import fr.openwide.core.jpa.business.generic.dao.IEntityDao;
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.business.generic.model.GenericEntityCollectionReference;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
+import fr.openwide.core.jpa.business.generic.model.IReferenceable;
 
 @Service("entityService")
 public class EntityServiceImpl implements IEntityService {
@@ -24,7 +25,7 @@ public class EntityServiceImpl implements IEntityService {
 	}
 	
 	@Override
-	public <E extends GenericEntity<?, ?>> E getEntity(GenericEntityReference<?, E> reference) {
+	public <E extends GenericEntity<?, ?>> E getEntity(IReference<E> reference) {
 		return entityDao.getEntity(reference);
 	}
 	
@@ -39,8 +40,8 @@ public class EntityServiceImpl implements IEntityService {
 	}
 	
 	@Override
-	public <K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> E getEntity(E entity) {
-		return entityDao.getEntity(GenericEntityReference.of(entity));
+	public <E extends GenericEntity<?, ?>> E getEntity(IReferenceable<E> referenceable) {
+		return entityDao.getEntity(referenceable.asReference());
 	}
 	
 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/GenericEntityServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/GenericEntityServiceImpl.java
@@ -24,7 +24,7 @@ import javax.persistence.metamodel.SingularAttribute;
 
 import fr.openwide.core.jpa.business.generic.dao.IGenericEntityDao;
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 import fr.openwide.core.jpa.business.generic.util.GenericEntityUtils;
 import fr.openwide.core.jpa.exception.SecurityServiceException;
 import fr.openwide.core.jpa.exception.ServiceException;
@@ -87,7 +87,7 @@ public abstract class GenericEntityServiceImpl<K extends Serializable & Comparab
 	}
 	
 	@Override
-	public <T extends E> T getById(GenericEntityReference<K, T> reference) {
+	public <T extends E> T getById(IReference<T> reference) {
 		return genericDao.getById(reference);
 	}
 

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/IEntityService.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/IEntityService.java
@@ -7,22 +7,24 @@ import java.util.List;
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
 import fr.openwide.core.jpa.business.generic.model.GenericEntityCollectionReference;
 import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
+import fr.openwide.core.jpa.business.generic.model.IReferenceable;
 
 public interface IEntityService extends ITransactionalAspectAwareService {
 	
 	<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> E getEntity(Class<E> clazz, K id);
 	
-	<E extends GenericEntity<?, ?>> E getEntity(GenericEntityReference<?, E> reference);
+	<E extends GenericEntity<?, ?>> E getEntity(IReference<E> reference);
 
 	<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> List<E> listEntity(Class<E> clazz, Collection<K> ids);
 
 	<E extends GenericEntity<?, ?>> List<E> listEntity(GenericEntityCollectionReference<?, E> reference);
 	
 	/**
-	 * @param entity An object representing an entity that may have been detached from the session
-	 * @return An object representing the same entity, but which is attached to the session
+	 * @param entity A {@link GenericEntity} (that may have been detached from the session) or a {@link GenericEntityReference}
+	 * @return An object representing the same entity, but which is guaranteed to be attached to the session
 	 */
-	<K extends Serializable & Comparable<K>, E extends GenericEntity<K, ?>> E getEntity(E entity);
+	<E extends GenericEntity<?, ?>> E getEntity(IReferenceable<E> referenceOrEntity);
 	
 	void flush();
 	

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/IGenericEntityService.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/IGenericEntityService.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import fr.openwide.core.commons.util.security.PermissionObject;
 import fr.openwide.core.jpa.business.generic.model.GenericEntity;
-import fr.openwide.core.jpa.business.generic.model.GenericEntityReference;
+import fr.openwide.core.jpa.business.generic.model.IReference;
 import fr.openwide.core.jpa.exception.SecurityServiceException;
 import fr.openwide.core.jpa.exception.ServiceException;
 
@@ -111,7 +111,7 @@ public interface IGenericEntityService<K extends Serializable & Comparable<K>, E
 	 * @param reference
 	 * @return entité
 	 */
-	<T extends E> T getById(GenericEntityReference<K, T> reference);
+	<T extends E> T getById(IReference<T> reference);
 	
 	/**
 	 * Renvoie la liste de l'ensemble des entités de ce type.

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/util/References.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/util/References.java
@@ -1,0 +1,16 @@
+package fr.openwide.core.jpa.business.generic.util;
+
+import fr.openwide.core.jpa.business.generic.model.IReference;
+import fr.openwide.core.jpa.business.generic.model.IReferenceable;
+
+public final class References {
+	
+	private References() {
+	}
+	
+	@SuppressWarnings("unchecked") // IReference<T> is covariant in T, so this cast is harmless 
+	public static <T> IReference<T> asReference(IReferenceable<? extends T> referenceable) {
+		return referenceable == null ? null : (IReference<T>)referenceable.asReference();
+	}
+	
+}


### PR DESCRIPTION
These interfaces allow to build APIs that accept IReferenceable as an input, which would
allow clients to give either a GenericEntityReference or a GenericEntity as input.

This also paves the way toward generic services, DAO, etc. that would not have the ID
type as a generic type parameter.
