### PR TITLE
Always handle InterruptedException when catching Exception

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-migration/src/main/java/fr/openwide/core/jpa/migration/transaction/TransactionWrapperCallable.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-migration/src/main/java/fr/openwide/core/jpa/migration/transaction/TransactionWrapperCallable.java
@@ -30,6 +30,9 @@ public class TransactionWrapperCallable<T> implements Callable<T> {
 				try {
 					return callable.call();
 				} catch (Exception e) {
+					if (e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
 					LOGGER.error("L'erreur suivante n'est pas traitée ; il faut obligatoirement traiter toutes les erreurs. Rollback de la transaction.", e);
 					transactionStatus.setRollbackOnly();
 					return null;

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/history/util/FactoredHistoryLogBeforeCommitWithDifferencesTask.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/business/history/util/FactoredHistoryLogBeforeCommitWithDifferencesTask.java
@@ -90,6 +90,9 @@ public class FactoredHistoryLogBeforeCommitWithDifferencesTask implements ITrans
 			try {
 				this.reference = referenceProvider.call();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				throw new IllegalStateException("Error retrieving a reference object for a diff", e);
 			}
 		}

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/util/transaction/service/TransactionSynchronizationTaskManagerServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-more/src/main/java/fr/openwide/core/jpa/more/util/transaction/service/TransactionSynchronizationTaskManagerServiceImpl.java
@@ -124,6 +124,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 					beforeCommitTask.run();
 					entityManagerUtils.getCurrentEntityManager().flush();
 				} catch (Exception e) {
+					if (e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
 					// This exception MUST be thrown, as we want to rollback if anything goes wrong.
 					// We better ignore other tasks, as they will have no effect on the current transaction.
 					throw new TransactionSynchronizationException("Error while executing a 'before clear' task.", e);
@@ -155,6 +158,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 			try {
 				beforeCommitTask.run();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				// This exception MUST be thrown, as we want to rollback if anything goes wrong.
 				// We better ignore other tasks, as they will have no effect on the current transaction.
 				throw new TransactionSynchronizationException("Error while executing a 'before commit' task.", e);
@@ -172,6 +178,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 			try {
 				afterCommitTask.run();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				if (firstException == null) {
 					firstException = e;
 				} else {
@@ -196,6 +205,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 			try {
 				((ITransactionSynchronizationTaskRollbackAware) afterCommitTask).afterRollback();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				if (firstException == null) {
 					firstException = e;
 				} else {
@@ -208,6 +220,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 			try {
 				((ITransactionSynchronizationTaskRollbackAware) beforeCommitTask).afterRollback();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				if (firstException == null) {
 					firstException = e;
 				} else {
@@ -220,6 +235,9 @@ public class TransactionSynchronizationTaskManagerServiceImpl
 			try {
 				beforeClearTask.afterRollback();
 			} catch (Exception e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				if (firstException == null) {
 					firstException = e;
 				} else {

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/main/java/fr/openwide/core/jpa/security/service/CoreSecurityServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/main/java/fr/openwide/core/jpa/security/service/CoreSecurityServiceImpl.java
@@ -176,6 +176,9 @@ public class CoreSecurityServiceImpl implements ISecurityService {
 		try {
 			return task.call();
 		} catch (Exception e) {
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
 			throw new RuntimeException(e);
 		} finally {
 			AuthenticationUtil.setAuthentication(originalAuthentication);
@@ -189,6 +192,9 @@ public class CoreSecurityServiceImpl implements ISecurityService {
 		try {
 			return task.call();
 		} catch (Exception e) {
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
 			throw new RuntimeException(e);
 		} finally {
 			AuthenticationUtil.setAuthentication(originalAuthentication);

--- a/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/TransactionScopeIndependantRunnerServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa/src/main/java/fr/openwide/core/jpa/business/generic/service/TransactionScopeIndependantRunnerServiceImpl.java
@@ -44,6 +44,9 @@ public class TransactionScopeIndependantRunnerServiceImpl implements ITransactio
 				try {
 					return callable.call();
 				} catch (Exception e) {
+					if (e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
 					throw new IllegalStateException(String.format("Erreur durant l'execution du callable %s", callable), e);
 				}
 			}

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/notification/service/AbstractNotificationPanelRendererServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/notification/service/AbstractNotificationPanelRendererServiceImpl.java
@@ -54,6 +54,9 @@ public abstract class AbstractNotificationPanelRendererServiceImpl
 						try {
 							return componentTask.call();
 						} catch (Exception e) {
+							if (e instanceof InterruptedException) {
+								Thread.currentThread().interrupt();
+							}
 							throw new RuntimeException(e); // Do wrap
 						}
 					}

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/notification/service/AbstractNotificationUrlBuilderServiceImpl.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/main/java/fr/openwide/core/wicket/more/notification/service/AbstractNotificationUrlBuilderServiceImpl.java
@@ -51,6 +51,9 @@ public abstract class AbstractNotificationUrlBuilderServiceImpl implements ICont
 		} catch (RuntimeException e) {
 			throw e;
 		} catch (Exception e) {
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
 			throw new RuntimeException(e);
 		}
 	}


### PR DESCRIPTION
If we just swallow the exception, or use it as another exception's cause, then the interruption won't be notified to callers, which is bad practice.
In this commit, the cases where we can't just re-throw the InterruptedException were handled by setting the thread's interrupt status.

See http://www.ibm.com/developerworks/library/j-jtp05236/
