### PR TITLE
AuthenticationUtil : principal can be the username

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/main/java/fr/openwide/core/jpa/security/service/AuthenticationUtil.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-jpa-security/src/main/java/fr/openwide/core/jpa/security/service/AuthenticationUtil.java
@@ -24,15 +24,16 @@ final class AuthenticationUtil {
 	}
 
 	static String getUserName() {
-		String userName = null;
-
 		Authentication authentication = getAuthentication();
-		if (authentication != null && (authentication.getPrincipal() instanceof UserDetails)) {
-			UserDetails details = (UserDetails) authentication.getPrincipal();
-			userName = details.getUsername();
+		if (authentication != null) {
+			Object principal = authentication.getPrincipal();
+			if (principal instanceof String) {
+				return (String) principal;
+			} else if (principal instanceof UserDetails) {
+				return ((UserDetails) principal).getUsername();
+			}
 		}
-
-		return userName;
+		return null;
 	}
 
 	static Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
In some cases, principal is not a UserDetails but just a String object. Regarding to the Authentication#getPrincipal() javadoc, this string is the username, so we can return it.
This should occur when using a RunAsSystemToken for example.
