### PR TITLE
Bindable model chained call same model

### DIFF
--- a/owsi-core/owsi-core-components/owsi-core-component-commons/src/main/java/fr/openwide/core/commons/util/fieldpath/FieldPath.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-commons/src/main/java/fr/openwide/core/commons/util/fieldpath/FieldPath.java
@@ -176,6 +176,14 @@ public class FieldPath implements Iterable<FieldPathComponent>, Serializable { /
 		}
 	}
 	
+	public Optional<FieldPath> relativeToParent() {
+		if (isRoot()) {
+			return Optional.absent();
+		} else {
+			return relativeTo(parent().get());
+		}
+	}
+	
 	public FieldPath append(FieldPath other) {
 		return new FieldPath(components, other.components);
 	}

--- a/owsi-core/owsi-core-components/owsi-core-component-commons/src/main/java/fr/openwide/core/commons/util/fieldpath/FieldPathPropertyComponent.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-commons/src/main/java/fr/openwide/core/commons/util/fieldpath/FieldPathPropertyComponent.java
@@ -7,7 +7,9 @@ public class FieldPathPropertyComponent extends FieldPathComponent {
 
 	private static final long serialVersionUID = 2111693502794024737L;
 
-	public static final String PROPERTY_SEPARATOR = ".";
+	public static final char PROPERTY_SEPARATOR_CHAR = '.';
+
+	public static final String PROPERTY_SEPARATOR = String.valueOf(PROPERTY_SEPARATOR_CHAR);
 	
 	private final String propertyName;
 

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/RootValue.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/RootValue.java
@@ -14,6 +14,7 @@ import fr.openwide.core.commons.util.collections.CollectionUtils;
 class RootValue {
 	
 	private SimplePropertyValue simpleProperty;
+	private RootValue compositeProperty;
 	private Collection<CollectionPropertyItemValue> collectionProperty = Lists.newArrayList();
 	private Map<MapPropertyItemKey, MapPropertyItemValue> mapProperty = Maps.newLinkedHashMap();
 	
@@ -25,6 +26,14 @@ class RootValue {
 		this.simpleProperty = simpleProperty;
 	}
 	
+	public RootValue getCompositeProperty() {
+		return compositeProperty;
+	}
+
+	public void setCompositeProperty(RootValue compositeProperty) {
+		this.compositeProperty = compositeProperty;
+	}
+
 	public Collection<CollectionPropertyItemValue> getCollectionProperty() {
 		return collectionProperty;
 	}

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableCollectionModel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableCollectionModel.java
@@ -30,6 +30,31 @@ public class TestBindableCollectionModel extends AbstractTestBindableModel {
 		);
 		IBindableModel<?> secondCall = bindableModel.bindCollectionAlreadyAdded(rootBinding().collectionProperty());
 		assertSame(firstCall, secondCall);
+		IBindableModel<?> thirdCall = bindableModel.bindCollectionWithCache(
+				rootBinding().collectionProperty(),
+				Suppliers2.<CollectionPropertyItemValue>arrayList(), StubModel.<CollectionPropertyItemValue>factory()
+		);
+		assertSame(firstCall, thirdCall);
+	}
+	
+	@Test
+	public void alwaysReturnsSameModelInstanceEvenIfChained() {
+		doReturn(rootValue).when(rootModel).getObject();
+		
+		IBindableModel<RootValue> bindableModel = new BindableModel<>(rootModel);
+		IBindableModel<?> directCall = bindableModel.bindCollectionWithCache(
+				rootBinding().compositeProperty().collectionProperty(),
+				Suppliers2.<CollectionPropertyItemValue>arrayList(), StubModel.<CollectionPropertyItemValue>factory()
+		);
+		IBindableModel<?> chainedCall = bindableModel.bind(rootBinding().compositeProperty())
+				.bindCollectionAlreadyAdded(rootBinding().collectionProperty());
+		assertSame(directCall, chainedCall);
+		IBindableModel<?> chainedCallWithCache = bindableModel.bind(rootBinding().compositeProperty())
+				.bindCollectionWithCache(
+						rootBinding().collectionProperty(),
+						Suppliers2.<CollectionPropertyItemValue>arrayList(), StubModel.<CollectionPropertyItemValue>factory()
+				);
+		assertSame(directCall, chainedCallWithCache);
 	}
 
 	@Test

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableMapModel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableMapModel.java
@@ -31,6 +31,34 @@ public class TestBindableMapModel extends AbstractTestBindableModel {
 		);
 		IBindableModel<?> secondCall = bindableModel.bindMapAlreadyAdded(rootBinding().mapProperty());
 		assertSame(firstCall, secondCall);
+		IBindableModel<?> thirdCall = bindableModel.bindMapWithCache(
+				rootBinding().mapProperty(),
+				Suppliers2.<MapPropertyItemKey, MapPropertyItemValue>linkedHashMap(),
+				StubModel.<MapPropertyItemKey>factory(), StubModel.<MapPropertyItemValue>factory()
+		);
+		assertSame(firstCall, thirdCall);
+	}
+	
+	@Test
+	public void alwaysReturnsSameModelInstanceEvenIfChained() {
+		doReturn(rootValue).when(rootModel).getObject();
+		
+		IBindableModel<RootValue> bindableModel = new BindableModel<>(rootModel);
+		IBindableModel<?> directCall = bindableModel.bindMapWithCache(
+				rootBinding().compositeProperty().mapProperty(),
+				Suppliers2.<MapPropertyItemKey, MapPropertyItemValue>linkedHashMap(),
+				StubModel.<MapPropertyItemKey>factory(), StubModel.<MapPropertyItemValue>factory()
+		);
+		IBindableModel<?> chainedCall = bindableModel.bind(rootBinding().compositeProperty())
+				.bindMapAlreadyAdded(rootBinding().mapProperty());
+		assertSame(directCall, chainedCall);
+		IBindableModel<?> chainedCallWithCache = bindableModel.bind(rootBinding().compositeProperty())
+				.bindMapWithCache(
+						rootBinding().mapProperty(),
+						Suppliers2.<MapPropertyItemKey, MapPropertyItemValue>linkedHashMap(),
+						StubModel.<MapPropertyItemKey>factory(), StubModel.<MapPropertyItemValue>factory()
+				);
+		assertSame(directCall, chainedCallWithCache);
 	}
 
 	@Test

--- a/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableModel.java
+++ b/owsi-core/owsi-core-components/owsi-core-component-wicket-more/src/test/java/fr/openwide/core/test/wicket/more/bindable/TestBindableModel.java
@@ -49,6 +49,20 @@ public class TestBindableModel extends AbstractTestBindableModel {
 		IBindableModel<?> thirdCall = bindableModel.bindWithCache(rootBinding().simpleProperty(), new StubModel<SimplePropertyValue>());
 		assertSame(firstCall, thirdCall);
 	}
+	
+	@Test
+	public void alwaysReturnsSameModelInstanceEvenIfChained() {
+		doReturn(rootValue).when(rootModel).getObject();
+		
+		IBindableModel<RootValue> bindableModel = new BindableModel<>(rootModel);
+		IBindableModel<?> directCall = bindableModel.bind(rootBinding().compositeProperty().simpleProperty());
+		IBindableModel<?> chainedCall = bindableModel.bind(rootBinding().compositeProperty()).bind(rootBinding().simpleProperty());
+		assertSame(directCall, chainedCall);
+		IBindableModel<?> chainedCallWithCache =
+				bindableModel.bind(rootBinding().compositeProperty())
+				.bindWithCache(rootBinding().simpleProperty(), new StubModel<SimplePropertyValue>());
+		assertSame(directCall, chainedCallWithCache);
+	}
 
 	@Test
 	public void simpleCacheUsage() {


### PR DESCRIPTION
Now, these two calls will return the same model:
1. `bindableModel.bind(Bindings.a().b().c())`
2. `bindableModel.bind(Bindings.a().b()).bind(Bindings.b().c())`

This ensures that the two calls will share the same cache. Which is what one would expect, actually.
